### PR TITLE
add script to setup rabbitmq + celery on server with systemd configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,13 @@ DJANGO_SECRET_KEY="your-secret-key-here-replace-in-production"
 # Optional Django Settings
 DJANGO_DEBUG="False"
 
-# Celery Configuration (Optional)
+# Celery Configuration
 CELERY_BROKER_URL="amqp://guest:guest@localhost:5672//"
+# Additional Celery settings (production will override these)
+CELERY_WORKERS=2
+CELERY_WORKER_CONCURRENCY=4
+CELERY_WORKER_MAX_TASKS_PER_CHILD=1000
+CELERY_TASK_TIME_LIMIT=1800
+CELERY_TASK_SOFT_TIME_LIMIT=1740
+CELERY_LOG_LEVEL="info"
 

--- a/deploy/DEBUGGING.md
+++ b/deploy/DEBUGGING.md
@@ -7,6 +7,8 @@ This document contains detailed troubleshooting information for the ProEnergia d
 - **Web Server**: Nginx (reverse proxy, static files, SSL termination)
 - **Application Server**: Gunicorn (WSGI server)
 - **Database**: PostgreSQL 16 with PostGIS extension
+- **Message Broker**: RabbitMQ (for Celery)
+- **Task Queue**: Celery (background tasks and scheduling)
 - **Process Management**: systemd
 - **Deployment**: Webhook listener + deployment wrapper script
 
@@ -26,6 +28,8 @@ This document contains detailed troubleshooting information for the ProEnergia d
 - **Deploy Script**: `/usr/local/bin/deploy-proenergia`
 - **Update Script**: `/var/www/proenergia/app/deploy/scripts/04_update_app_nosudo.sh`
 - **Sudoers Config**: `/etc/sudoers.d/proenergia-deploy`
+- **Celery Worker Service**: `/etc/systemd/system/proenergia-celery.service`
+- **Celery Beat Service**: `/etc/systemd/system/proenergia-celerybeat.service`
 
 ## Monitoring
 
@@ -70,6 +74,37 @@ tail -f /var/log/proenergia/gunicorn_error.log
 
 # Monitor resource usage
 htop  # or top
+```
+
+### Celery and RabbitMQ Monitoring
+```bash
+# Check Celery worker status
+sudo systemctl status proenergia-celery
+
+# Check Celery beat status
+sudo systemctl status proenergia-celerybeat
+
+# View Celery worker logs
+sudo journalctl -u proenergia-celery -f
+
+# View Celery beat logs
+sudo journalctl -u proenergia-celerybeat -f
+
+# Check RabbitMQ status
+sudo systemctl status rabbitmq-server
+sudo rabbitmqctl status
+
+# List RabbitMQ queues
+sudo rabbitmqctl list_queues name messages consumers
+
+# Check RabbitMQ users and vhosts
+sudo rabbitmqctl list_users
+sudo rabbitmqctl list_vhosts
+
+# Monitor Celery tasks (from app directory)
+cd /var/www/proenergia/app
+sudo -u proenergia bash -c "source venv/bin/activate && celery -A proenergia inspect active"
+sudo -u proenergia bash -c "source venv/bin/activate && celery -A proenergia inspect stats"
 ```
 
 ## Common Issues and Solutions
@@ -196,6 +231,79 @@ This means nginx can't connect to Gunicorn.
    ```bash
    sudo systemctl status certbot.timer
    sudo journalctl -u certbot.timer
+   ```
+
+### Celery Worker Not Processing Tasks
+
+1. Check worker is running:
+   ```bash
+   sudo systemctl status proenergia-celery
+   ps aux | grep celery
+   ```
+
+2. Check RabbitMQ connectivity:
+   ```bash
+   sudo rabbitmqctl status
+   sudo rabbitmqctl list_queues
+   ```
+
+3. Verify broker URL in .env:
+   ```bash
+   sudo grep CELERY_BROKER_URL /var/www/proenergia/app/.env
+   ```
+
+4. Test Celery connection manually:
+   ```bash
+   cd /var/www/proenergia/app
+   sudo -u proenergia bash -c "source venv/bin/activate && celery -A proenergia inspect ping"
+   ```
+
+5. Check for import errors:
+   ```bash
+   cd /var/www/proenergia/app
+   sudo -u proenergia bash -c "source venv/bin/activate && python -c 'from proenergia.celery import app; print(app)'"
+   ```
+
+### Celery Tasks Timing Out
+
+1. Check task time limits in .env:
+   ```bash
+   grep CELERY_TASK_TIME_LIMIT /var/www/proenergia/app/.env
+   ```
+
+2. Monitor long-running tasks:
+   ```bash
+   sudo -u proenergia bash -c "cd /var/www/proenergia/app && source venv/bin/activate && celery -A proenergia inspect active"
+   ```
+
+3. Increase time limits if needed:
+   ```bash
+   sudo nano /var/www/proenergia/app/.env
+   # Update CELERY_TASK_TIME_LIMIT and CELERY_TASK_SOFT_TIME_LIMIT
+   sudo systemctl restart proenergia-celery
+   ```
+
+### RabbitMQ Connection Refused
+
+1. Check RabbitMQ is running:
+   ```bash
+   sudo systemctl status rabbitmq-server
+   sudo systemctl start rabbitmq-server
+   ```
+
+2. Verify user permissions:
+   ```bash
+   sudo rabbitmqctl list_users
+   sudo rabbitmqctl list_user_permissions proenergia
+   ```
+
+3. Reset RabbitMQ user if needed:
+   ```bash
+   sudo rabbitmqctl delete_user proenergia
+   sudo rabbitmqctl add_user proenergia NEW_PASSWORD
+   sudo rabbitmqctl set_permissions -p proenergia proenergia ".*" ".*" ".*"
+   # Update password in /var/www/proenergia/app/.env
+   sudo systemctl restart proenergia-celery
    ```
 
 ### Database Issues
@@ -352,12 +460,17 @@ journalctl --disk-usage  # Check journal size
 # Service management
 sudo systemctl {start|stop|restart|status} proenergia
 sudo systemctl {start|stop|restart|status} proenergia-webhook
+sudo systemctl {start|stop|restart|status} proenergia-celery
+sudo systemctl {start|stop|restart|status} proenergia-celerybeat
+sudo systemctl {start|stop|restart|status} rabbitmq-server
 sudo systemctl {start|stop|restart|status} nginx
 sudo systemctl {start|stop|restart|status} postgresql
 
 # Log viewing
 sudo journalctl -u proenergia -f          # App logs
 sudo journalctl -u proenergia-webhook -f  # Webhook logs
+sudo journalctl -u proenergia-celery -f    # Celery worker logs
+sudo journalctl -u proenergia-celerybeat -f # Celery beat logs
 tail -f /var/log/proenergia/*.log        # All ProEnergia logs
 tail -f /var/log/nginx/*.log             # Nginx logs
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -56,7 +56,18 @@ This automatically:
 - **Sets up webhook listener for automated deployment**
 - **Displays a webhook secret - save this!**
 
-### 6. Enable Automated Deployment
+### 6. Setup Celery and RabbitMQ
+```bash
+./scripts/06_setup_rabbitmq_celery.sh
+```
+
+This will:
+- Install and configure RabbitMQ
+- Set up Celery worker and beat services
+- Auto-generate secure RabbitMQ credentials
+- Add configuration to your .env file
+
+### 7. Enable Automated Deployment
 
 Using the webhook secret from step 5:
 
@@ -84,6 +95,12 @@ sudo journalctl -u proenergia -f
 
 # Restart application
 sudo systemctl restart proenergia
+
+# Celery services
+sudo systemctl status proenergia-celery      # Check worker status
+sudo systemctl status proenergia-celerybeat  # Check beat status
+sudo journalctl -u proenergia-celery -f      # View worker logs
+sudo journalctl -u proenergia-celerybeat -f  # View beat logs
 ```
 
 ## File Locations

--- a/deploy/configs/systemd/proenergia-celery.service
+++ b/deploy/configs/systemd/proenergia-celery.service
@@ -1,0 +1,49 @@
+[Unit]
+Description=ProEnergia Celery Worker
+After=network.target rabbitmq-server.service postgresql.service
+Wants=rabbitmq-server.service postgresql.service
+
+[Service]
+Type=exec
+User=proenergia
+Group=proenergia
+WorkingDirectory=/var/www/proenergia/app
+Environment=PATH=/var/www/proenergia/app/venv/bin
+Environment=DJANGO_SETTINGS_MODULE=proenergia.config
+Environment=DJANGO_CONFIGURATION=Production
+EnvironmentFile=/var/www/proenergia/app/.env
+
+# Start Celery with configurable workers (default 2)
+ExecStart=/bin/bash -c '/var/www/proenergia/app/venv/bin/celery -A proenergia worker \
+    --loglevel=${CELERY_LOG_LEVEL:-info} \
+    --concurrency=${CELERY_WORKER_CONCURRENCY:-4} \
+    --max-tasks-per-child=${CELERY_WORKER_MAX_TASKS_PER_CHILD:-1000} \
+    --time-limit=${CELERY_TASK_TIME_LIMIT:-1800} \
+    --soft-time-limit=${CELERY_TASK_SOFT_TIME_LIMIT:-1740}'
+
+# Graceful shutdown
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=300
+SendSIGKILL=no
+
+# Restart policy
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=3
+StartLimitInterval=60
+
+# Security settings
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/www/proenergia /var/log/proenergia /var/run/proenergia-celery
+
+# Resource limits
+LimitNOFILE=65536
+MemoryHigh=3G
+MemoryMax=4G
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/configs/systemd/proenergia-celerybeat.service
+++ b/deploy/configs/systemd/proenergia-celerybeat.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=ProEnergia Celery Beat Scheduler
+After=network.target rabbitmq-server.service postgresql.service
+Wants=rabbitmq-server.service postgresql.service
+
+[Service]
+Type=exec
+User=proenergia
+Group=proenergia
+WorkingDirectory=/var/www/proenergia/app
+Environment=PATH=/var/www/proenergia/app/venv/bin
+Environment=DJANGO_SETTINGS_MODULE=proenergia.config
+Environment=DJANGO_CONFIGURATION=Production
+EnvironmentFile=/var/www/proenergia/app/.env
+
+# Start Celery Beat with database scheduler
+ExecStart=/var/www/proenergia/app/venv/bin/celery -A proenergia beat \
+    --loglevel=${CELERY_LOG_LEVEL:-info} \
+    --scheduler django_celery_beat.schedulers:DatabaseScheduler
+
+# Graceful shutdown
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=10
+
+# Restart policy
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=3
+StartLimitInterval=60
+
+# Security settings
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/www/proenergia /var/log/proenergia /var/run/proenergia-celery
+
+# Resource limits (Beat uses minimal resources)
+LimitNOFILE=4096
+MemoryHigh=256M
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/scripts/06_setup_rabbitmq_celery.sh
+++ b/deploy/scripts/06_setup_rabbitmq_celery.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -e
+
+echo "=== Setting up RabbitMQ and Celery ==="
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root (use sudo)"
+   exit 1
+fi
+
+echo "Installing RabbitMQ server..."
+apt update
+apt install -y rabbitmq-server
+
+# Start and enable RabbitMQ
+systemctl start rabbitmq-server
+systemctl enable rabbitmq-server
+
+echo "Configuring RabbitMQ..."
+
+# Generate a secure password for RabbitMQ
+RABBITMQ_PASSWORD=$(openssl rand -base64 32)
+
+# Create RabbitMQ user and vhost for Celery
+rabbitmqctl add_user proenergia "$RABBITMQ_PASSWORD" 2>/dev/null || echo "User already exists"
+rabbitmqctl add_vhost proenergia 2>/dev/null || echo "Vhost already exists"
+rabbitmqctl set_permissions -p proenergia proenergia ".*" ".*" ".*"
+rabbitmqctl set_user_tags proenergia administrator
+
+echo "Installing Celery systemd services..."
+
+# Copy Celery worker service
+cp /var/www/proenergia/app/deploy/configs/systemd/proenergia-celery.service /etc/systemd/system/
+cp /var/www/proenergia/app/deploy/configs/systemd/proenergia-celerybeat.service /etc/systemd/system/
+
+# Create runtime directory for Celery
+mkdir -p /var/run/proenergia-celery
+chown proenergia:proenergia /var/run/proenergia-celery
+
+# Create tmpfiles.d config to recreate directory on boot
+echo "d /var/run/proenergia-celery 0755 proenergia proenergia -" > /etc/tmpfiles.d/proenergia-celery.conf
+
+# Update .env file with RabbitMQ connection string if not already present
+ENV_FILE="/var/www/proenergia/app/.env"
+if ! grep -q "CELERY_BROKER_URL" "$ENV_FILE"; then
+    echo "" >> "$ENV_FILE"
+    echo "# Celery Configuration" >> "$ENV_FILE"
+    echo "CELERY_BROKER_URL=\"amqp://proenergia:${RABBITMQ_PASSWORD}@localhost:5672/proenergia\"" >> "$ENV_FILE"
+    echo "CELERY_WORKERS=2" >> "$ENV_FILE"
+    echo "CELERY_WORKER_CONCURRENCY=4" >> "$ENV_FILE"
+    echo "CELERY_WORKER_MAX_TASKS_PER_CHILD=1000" >> "$ENV_FILE"
+    echo "CELERY_TASK_TIME_LIMIT=1800" >> "$ENV_FILE"
+    echo "CELERY_TASK_SOFT_TIME_LIMIT=1740" >> "$ENV_FILE"
+fi
+
+# Reload systemd and enable services
+systemctl daemon-reload
+systemctl enable proenergia-celery
+systemctl enable proenergia-celerybeat
+
+# Start services
+systemctl start proenergia-celery
+systemctl start proenergia-celerybeat
+
+# Test RabbitMQ connection
+if rabbitmqctl status > /dev/null 2>&1; then
+    echo "✓ RabbitMQ is running"
+else
+    echo "✗ RabbitMQ failed to start"
+    exit 1
+fi
+
+# Check Celery services
+sleep 3
+if systemctl is-active --quiet proenergia-celery; then
+    echo "✓ Celery worker is running"
+else
+    echo "✗ Celery worker failed to start"
+    echo "Check logs with: journalctl -u proenergia-celery -n 50"
+fi
+
+if systemctl is-active --quiet proenergia-celerybeat; then
+    echo "✓ Celery beat is running"
+else
+    echo "✗ Celery beat failed to start"
+    echo "Check logs with: journalctl -u proenergia-celerybeat -n 50"
+fi
+
+echo ""
+echo "=== RabbitMQ and Celery setup complete ==="
+echo ""
+echo "Important: The RabbitMQ password has been set and saved to $ENV_FILE"
+echo ""
+echo "Service management commands:"
+echo "  sudo systemctl status proenergia-celery      - Check Celery worker status"
+echo "  sudo systemctl status proenergia-celerybeat  - Check Celery beat status"
+echo "  sudo systemctl status rabbitmq-server        - Check RabbitMQ status"
+echo ""
+echo "View logs:"
+echo "  sudo journalctl -u proenergia-celery -f      - Celery worker logs"
+echo "  sudo journalctl -u proenergia-celerybeat -f  - Celery beat logs"
+echo ""
+echo "Test Celery:"
+echo "  curl -X POST http://localhost:8000/api/v1/tasks/hello/ -H \"Content-Type: application/json\" -d '{\"name\": \"Test\"}'"

--- a/deploy/scripts/deploy-wrapper.sh
+++ b/deploy/scripts/deploy-wrapper.sh
@@ -31,14 +31,23 @@ fi
 
 log "Application updated"
 
-# Restart service
+# Restart services
 if ! systemctl restart proenergia; then
     log "ERROR: Service restart failed"
     echo "Error: Service restart failed. Check logs: journalctl -u proenergia -f"
     exit 1
 fi
 
-log "Service restarted"
+# Restart Celery services if they are enabled
+if systemctl is-enabled --quiet proenergia-celery 2>/dev/null; then
+    systemctl restart proenergia-celery || log "WARNING: Celery worker restart failed"
+fi
+
+if systemctl is-enabled --quiet proenergia-celerybeat 2>/dev/null; then
+    systemctl restart proenergia-celerybeat || log "WARNING: Celery beat restart failed"
+fi
+
+log "Services restarted"
 log "Deployment completed successfully"
 
 echo "Deployment complete"


### PR DESCRIPTION
Fixes #26 -

 - Script to install rabbitmq on server, generate credentials and setup celery and celerybeat systemd services
 - Modifications to deploy script to restart celery services
 - Updates to README and DEBUGGING

cc @willemarcel 

