### PR TITLE
fix to pwd generation for rabbitmq to avoid special characters

### DIFF
--- a/deploy/configs/systemd/proenergia-celery.service
+++ b/deploy/configs/systemd/proenergia-celery.service
@@ -8,7 +8,7 @@ Type=exec
 User=proenergia
 Group=proenergia
 WorkingDirectory=/var/www/proenergia/app
-Environment=PATH=/var/www/proenergia/app/venv/bin
+Environment=PATH=/var/www/proenergia/app/venv/bin:/usr/local/bin:/usr/bin:/bin
 Environment=DJANGO_SETTINGS_MODULE=proenergia.config
 Environment=DJANGO_CONFIGURATION=Production
 EnvironmentFile=/var/www/proenergia/app/.env

--- a/deploy/configs/systemd/proenergia-celerybeat.service
+++ b/deploy/configs/systemd/proenergia-celerybeat.service
@@ -8,7 +8,7 @@ Type=exec
 User=proenergia
 Group=proenergia
 WorkingDirectory=/var/www/proenergia/app
-Environment=PATH=/var/www/proenergia/app/venv/bin
+Environment=PATH=/var/www/proenergia/app/venv/bin:/usr/local/bin:/usr/bin:/bin
 Environment=DJANGO_SETTINGS_MODULE=proenergia.config
 Environment=DJANGO_CONFIGURATION=Production
 EnvironmentFile=/var/www/proenergia/app/.env

--- a/deploy/scripts/06_setup_rabbitmq_celery.sh
+++ b/deploy/scripts/06_setup_rabbitmq_celery.sh
@@ -22,10 +22,10 @@ echo "Configuring RabbitMQ..."
 # Generate a secure password for RabbitMQ (alphanumeric only to avoid URL encoding issues)
 RABBITMQ_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | tr -d " ")
 
-# Create RabbitMQ user and vhost for Celery
+# Create RabbitMQ user for Celery (using default vhost)
 rabbitmqctl add_user proenergia "$RABBITMQ_PASSWORD" 2>/dev/null || echo "User already exists"
-rabbitmqctl add_vhost proenergia 2>/dev/null || echo "Vhost already exists"
-rabbitmqctl set_permissions -p proenergia proenergia ".*" ".*" ".*"
+# Set permissions on default vhost
+rabbitmqctl set_permissions -p / proenergia ".*" ".*" ".*"
 rabbitmqctl set_user_tags proenergia administrator
 
 echo "Installing Celery systemd services..."
@@ -46,7 +46,7 @@ ENV_FILE="/var/www/proenergia/app/.env"
 if ! grep -q "CELERY_BROKER_URL" "$ENV_FILE"; then
     echo "" >> "$ENV_FILE"
     echo "# Celery Configuration" >> "$ENV_FILE"
-    echo "CELERY_BROKER_URL=\"amqp://proenergia:${RABBITMQ_PASSWORD}@localhost:5672/proenergia\"" >> "$ENV_FILE"
+    echo "CELERY_BROKER_URL=\"amqp://proenergia:${RABBITMQ_PASSWORD}@localhost:5672//\"" >> "$ENV_FILE"
     echo "CELERY_WORKERS=2" >> "$ENV_FILE"
     echo "CELERY_WORKER_CONCURRENCY=4" >> "$ENV_FILE"
     echo "CELERY_WORKER_MAX_TASKS_PER_CHILD=1000" >> "$ENV_FILE"


### PR DESCRIPTION
If the password was generated with some special characters, it was causing URL encoding issues when specifying it in the `.env` and was just easier to make the password always alphanumeric than figure out correctly escaping in the `.env` file.
