### PR TITLE
Enable superadmins to toggle is_public and is_approved VectorDataset fields in the change/add page

### DIFF
--- a/proenergia/datasets/admin.py
+++ b/proenergia/datasets/admin.py
@@ -47,6 +47,12 @@ class VectorDatasetAdmin(PermissionBasedModelAdmin):
     fields = ["name", "description", "source"]
     actions = ["make_public", "make_private", "approve", "disapprove"]
 
+    def get_fields(self, request, obj=None):
+        fields = super().get_fields(request, obj)
+        if request.user.is_superuser:
+            return fields + ["is_public", "is_approved"]
+        return fields
+
     def save_model(self, request, obj, form, change):
         if not change:
             obj.created_by = request.user

--- a/proenergia/datasets/tests/test_vector_admin.py
+++ b/proenergia/datasets/tests/test_vector_admin.py
@@ -29,6 +29,9 @@ class VectorDatasetAdmin(TestCase):
         url = reverse("admin:datasets_vectordataset_add")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        # Superadmins can toggle public/approved fields
+        self.assertContains(response, "Is public")
+        self.assertContains(response, "Is approved")
 
         data = {
             "name": "Test Dataset",
@@ -49,6 +52,9 @@ class VectorDatasetAdmin(TestCase):
         url = reverse("admin:datasets_vectordataset_add")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        # should not include public/approved toggles
+        self.assertNotContains(response, "Is public")
+        self.assertNotContains(response, "Is approved")
 
         data = {
             "name": "Test Dataset",


### PR DESCRIPTION
Resolves https://github.com/developmentseed/moz-proenergia-internal/issues/50