### PR TITLE
add JSON editor for a single field in the Admin to test

### DIFF
--- a/proenergia/config/common.py
+++ b/proenergia/config/common.py
@@ -32,6 +32,8 @@ class Common(Configuration):
         "django_filters",  # for filtering rest endpoints
         "drf_spectacular",  # api-docs
         "corsheaders",
+        # JSON widget for admin
+        "django_json_widget",
         # Celery apps
         "django_celery_results",
         "django_celery_beat",

--- a/proenergia/datasets/admin.py
+++ b/proenergia/datasets/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin, messages
 from django.forms import ModelForm
+from django_json_widget.widgets import JSONEditorWidget
 from unfold.admin import ModelAdmin
 
 from .models import (
@@ -148,6 +149,17 @@ class DataModelAdminForm(ModelForm):
             "color_coding",
             "contextual_layers",
         ]
+        widgets = {
+            "filter_fields": JSONEditorWidget(
+                height="400px",
+                width="90%",
+                options={
+                    "mode": "tree",
+                    "modes": ["tree", "form", "view", "code", "text"],
+                    "search": True,
+                }
+            ),
+        }
 
     def clean(self):
         cleaned_data = super().clean()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ django-cors-headers==4.9.0
 
 # Admin tools
 django-unfold==0.72.0
+django-json-widget==2.0.1
 
 # Developer Tools
 ipdb==0.13.13


### PR DESCRIPTION
Refs https://github.com/developmentseed/moz-proenergia-internal/issues/44

uses `django-json-widget` to add a JSON editor to the `filter_fields` column to be able to test how it works. If it seems good, we can implement it across all JSON fields that are editable in the admin.