### PR TITLE
Modify summary endpoint response when a key is not found

### DIFF
--- a/proenergia/datasets/tests/test_scenario_data_views.py
+++ b/proenergia/datasets/tests/test_scenario_data_views.py
@@ -124,8 +124,9 @@ class TestScenarioDataDetailViews(APITestCase):
             "datasets:scenario-summary", args=[self.scenario_1.id, "nonexistent"]
         )
         res = self.client.get(url)
-        assert res.status_code == 404
-        assert "No data found for key" in res.data.get("error")
+        assert res.status_code == 200
+        assert res.data.get("key") == "nonexistent"
+        assert res.data.get("count") == 0
 
     def test_summary_nonexistent_scenario(self):
         """Test summary with non-existent scenario"""

--- a/proenergia/datasets/views.py
+++ b/proenergia/datasets/views.py
@@ -133,10 +133,7 @@ class SummaryView(APIView):
         entries_with_key = queryset.filter(metadata__has_key=key)
 
         if not entries_with_key.exists():
-            return Response(
-                {"error": f"No data found for key '{key}'."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+            return Response({"key": key, "count": 0})
 
         try:
             with transaction.atomic():


### PR DESCRIPTION
Return `{"key": key, "count": 0}` instead of a 404 error.