### PR TITLE
handle special characters in field names by sanitizing name

### DIFF
--- a/proenergia/datasets/aggregation/aggregators.py
+++ b/proenergia/datasets/aggregation/aggregators.py
@@ -479,19 +479,23 @@ class CombinedFieldAggregator:
 
         if numeric_fields and group_fields:
             # Execute grouped query with merged filter conditions
-            sql, params = self.query_builder.build_multi_field_grouped_query(
-                scenario_id,
-                numeric_fields,
-                group_fields,
-                filter_sql,
-                filter_params,
-                group_filter_conditions,
+            sql, params, alias_mapping = (
+                self.query_builder.build_multi_field_grouped_query(
+                    scenario_id,
+                    numeric_fields,
+                    group_fields,
+                    filter_sql,
+                    filter_params,
+                    group_filter_conditions,
+                )
             )
             results = self.query_builder.execute_query(sql, params)
 
             # Also get overall stats
-            overall_sql, overall_params = self.query_builder.build_multi_field_query(
-                scenario_id, numeric_fields, filter_sql, filter_params
+            overall_sql, overall_params, overall_alias_mapping = (
+                self.query_builder.build_multi_field_query(
+                    scenario_id, numeric_fields, filter_sql, filter_params
+                )
             )
             overall_results = self.query_builder.execute_query(
                 overall_sql, overall_params
@@ -500,24 +504,24 @@ class CombinedFieldAggregator:
 
             # Process results for each field
             for field_name, field_type in numeric_fields.items():
-                # Build overall summary
-                field_lower = field_name.lower()
+                # Build overall summary using sanitized alias
+                field_alias = self.query_builder.sanitize_field_for_alias(field_name)
                 summary = {
                     "type": "numeric",
-                    "count": overall_row.get(f"{field_lower}_count", 0) or 0,
+                    "count": overall_row.get(f"{field_alias}_count", 0) or 0,
                     "min": (
-                        float(overall_row.get(f"{field_lower}_min"))
-                        if overall_row.get(f"{field_lower}_min") is not None
+                        float(overall_row.get(f"{field_alias}_min"))
+                        if overall_row.get(f"{field_alias}_min") is not None
                         else None
                     ),
                     "max": (
-                        float(overall_row.get(f"{field_lower}_max"))
-                        if overall_row.get(f"{field_lower}_max") is not None
+                        float(overall_row.get(f"{field_alias}_max"))
+                        if overall_row.get(f"{field_alias}_max") is not None
                         else None
                     ),
                     "sum": (
-                        float(overall_row.get(f"{field_lower}_sum"))
-                        if overall_row.get(f"{field_lower}_sum") is not None
+                        float(overall_row.get(f"{field_alias}_sum"))
+                        if overall_row.get(f"{field_alias}_sum") is not None
                         else None
                     ),
                 }
@@ -529,20 +533,20 @@ class CombinedFieldAggregator:
                     for row in results:
                         group_value = row["group_value"]
                         grouped[group_value] = {
-                            "count": row.get(f"{field_lower}_count", 0) or 0,
+                            "count": row.get(f"{field_alias}_count", 0) or 0,
                             "min": (
-                                float(row.get(f"{field_lower}_min"))
-                                if row.get(f"{field_lower}_min") is not None
+                                float(row.get(f"{field_alias}_min"))
+                                if row.get(f"{field_alias}_min") is not None
                                 else None
                             ),
                             "max": (
-                                float(row.get(f"{field_lower}_max"))
-                                if row.get(f"{field_lower}_max") is not None
+                                float(row.get(f"{field_alias}_max"))
+                                if row.get(f"{field_alias}_max") is not None
                                 else None
                             ),
                             "sum": (
-                                float(row.get(f"{field_lower}_sum"))
-                                if row.get(f"{field_lower}_sum") is not None
+                                float(row.get(f"{field_alias}_sum"))
+                                if row.get(f"{field_alias}_sum") is not None
                                 else None
                             ),
                         }
@@ -568,20 +572,20 @@ class CombinedFieldAggregator:
                             grouped[group1_value] = {}
 
                         grouped[group1_value][group2_value] = {
-                            "count": row.get(f"{field_lower}_count", 0) or 0,
+                            "count": row.get(f"{field_alias}_count", 0) or 0,
                             "min": (
-                                float(row.get(f"{field_lower}_min"))
-                                if row.get(f"{field_lower}_min") is not None
+                                float(row.get(f"{field_alias}_min"))
+                                if row.get(f"{field_alias}_min") is not None
                                 else None
                             ),
                             "max": (
-                                float(row.get(f"{field_lower}_max"))
-                                if row.get(f"{field_lower}_max") is not None
+                                float(row.get(f"{field_alias}_max"))
+                                if row.get(f"{field_alias}_max") is not None
                                 else None
                             ),
                             "sum": (
-                                float(row.get(f"{field_lower}_sum"))
-                                if row.get(f"{field_lower}_sum") is not None
+                                float(row.get(f"{field_alias}_sum"))
+                                if row.get(f"{field_alias}_sum") is not None
                                 else None
                             ),
                         }
@@ -606,7 +610,7 @@ class CombinedFieldAggregator:
                 summaries[field_name] = summary
         elif numeric_fields:
             # Execute non-grouped query
-            sql, params = self.query_builder.build_multi_field_query(
+            sql, params, alias_mapping = self.query_builder.build_multi_field_query(
                 scenario_id, numeric_fields, filter_sql, filter_params
             )
             results = self.query_builder.execute_query(sql, params)
@@ -615,24 +619,26 @@ class CombinedFieldAggregator:
                 row = results[0]
                 # Process results for each field
                 for field_name, field_type in numeric_fields.items():
-                    # PostgreSQL converts column aliases to lowercase, so we need to match that
-                    field_lower = field_name.lower()
+                    # Use the sanitized alias to get results from the row
+                    field_alias = self.query_builder.sanitize_field_for_alias(
+                        field_name
+                    )
                     summaries[field_name] = {
                         "type": "numeric",
-                        "count": row.get(f"{field_lower}_count", 0) or 0,
+                        "count": row.get(f"{field_alias}_count", 0) or 0,
                         "min": (
-                            float(row.get(f"{field_lower}_min"))
-                            if row.get(f"{field_lower}_min") is not None
+                            float(row.get(f"{field_alias}_min"))
+                            if row.get(f"{field_alias}_min") is not None
                             else None
                         ),
                         "max": (
-                            float(row.get(f"{field_lower}_max"))
-                            if row.get(f"{field_lower}_max") is not None
+                            float(row.get(f"{field_alias}_max"))
+                            if row.get(f"{field_alias}_max") is not None
                             else None
                         ),
                         "sum": (
-                            float(row.get(f"{field_lower}_sum"))
-                            if row.get(f"{field_lower}_sum") is not None
+                            float(row.get(f"{field_alias}_sum"))
+                            if row.get(f"{field_alias}_sum") is not None
                             else None
                         ),
                     }

--- a/proenergia/datasets/aggregation/query_builder.py
+++ b/proenergia/datasets/aggregation/query_builder.py
@@ -6,6 +6,7 @@ with various combinations of filters and grouping. Raw SQL is used instead
 of Django ORM to achieve better performance for complex aggregations.
 """
 
+import re
 from typing import List, Tuple, Dict, Optional, Any
 from django.db import connection
 
@@ -21,6 +22,38 @@ class SummaryQueryBuilder:
 
     All queries use parameterized placeholders to prevent SQL injection.
     """
+
+    @staticmethod
+    def sanitize_field_for_alias(field_name: str) -> str:
+        """
+        Sanitize a field name to be used as a SQL column alias.
+
+        Replaces spaces and special characters with underscores to create
+        valid SQL identifiers. This ensures fields with special characters
+        like "Staple_Crop Production (t/y)" work correctly.
+
+        Args:
+            field_name: The original field name
+
+        Returns:
+            A sanitized version safe for use as a SQL alias
+        """
+        # Replace any non-alphanumeric characters (except underscores) with underscores
+        sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", field_name)
+
+        # Ensure it starts with a letter or underscore (SQL identifier rules)
+        if sanitized and not sanitized[0].isalpha() and sanitized[0] != "_":
+            sanitized = "f_" + sanitized
+
+        # Remove consecutive underscores and trailing underscores
+        sanitized = re.sub(r"_+", "_", sanitized)
+        sanitized = sanitized.strip("_")
+
+        # Ensure we always have a valid alias
+        if not sanitized:
+            sanitized = "field"
+
+        return sanitized.lower()  # PostgreSQL converts to lowercase anyway
 
     def build_filtered_query(
         self,
@@ -341,7 +374,7 @@ class SummaryQueryBuilder:
         fields: Dict[str, str],  # field_name -> field_type mapping
         filter_sql: str = "",
         filter_params: List = None,
-    ) -> Tuple[str, List]:
+    ) -> Tuple[str, List, Dict[str, str]]:
         """
         Build SQL for aggregating multiple fields in a single query.
 
@@ -355,7 +388,8 @@ class SummaryQueryBuilder:
             filter_params: Parameters for filter JOINs
 
         Returns:
-            Tuple of (SQL query, parameters)
+            Tuple of (SQL query, parameters, alias_mapping)
+            alias_mapping: Dict mapping sanitized aliases back to original field names
         """
         if filter_params is None:
             filter_params = []
@@ -366,24 +400,36 @@ class SummaryQueryBuilder:
 
         # Build SELECT clause with conditional aggregations
         select_parts = []
+        alias_mapping = {}  # Maps sanitized alias -> original field name
 
         # Add numeric field aggregations
         for field in numeric_fields:
             field_safe = field.replace("'", "''")  # Escape field name for SQL
+            field_alias = self.sanitize_field_for_alias(field)
+
+            # Track the mapping for each aggregation type
+            alias_mapping[f"{field_alias}_count"] = field
+            alias_mapping[f"{field_alias}_min"] = field
+            alias_mapping[f"{field_alias}_max"] = field
+            alias_mapping[f"{field_alias}_sum"] = field
+
             select_parts.extend(
                 [
-                    f"COUNT(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_count",
-                    f"MIN(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_min",
-                    f"MAX(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_max",
-                    f"SUM(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_sum",
+                    f"COUNT(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_count",
+                    f"MIN(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_min",
+                    f"MAX(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_max",
+                    f"SUM(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_sum",
                 ]
             )
 
         # For string fields, we need a different approach - get counts
         for field in string_fields:
             field_safe = field.replace("'", "''")
+            field_alias = self.sanitize_field_for_alias(field)
+            alias_mapping[f"{field_alias}_count"] = field
+
             select_parts.append(
-                f"COUNT(CASE WHEN m.key = '{field_safe}' THEN 1 END) as {field}_count"
+                f"COUNT(CASE WHEN m.key = '{field_safe}' THEN 1 END) as {field_alias}_count"
             )
 
         select_clause = ",\n                ".join(select_parts)
@@ -402,7 +448,7 @@ class SummaryQueryBuilder:
         """
 
         params = filter_params + [scenario_id]
-        return sql, params
+        return sql, params, alias_mapping
 
     def build_multi_field_grouped_query(
         self,
@@ -412,7 +458,7 @@ class SummaryQueryBuilder:
         filter_sql: str = "",
         filter_params: List = None,
         group_filter_conditions: Dict[str, Tuple[str, List]] = None,
-    ) -> Tuple[str, List]:
+    ) -> Tuple[str, List, Dict[str, str]]:
         """
         Build SQL for aggregating multiple fields with one or two group_by fields in a single query.
 
@@ -425,7 +471,8 @@ class SummaryQueryBuilder:
             group_filter_conditions: Dict mapping group field names to (condition_sql, params) for filters on group fields
 
         Returns:
-            Tuple of (SQL query, parameters)
+            Tuple of (SQL query, parameters, alias_mapping)
+            alias_mapping: Dict mapping sanitized aliases back to original field names
         """
         if filter_params is None:
             filter_params = []
@@ -437,6 +484,7 @@ class SummaryQueryBuilder:
 
         # Separate numeric and string fields
         numeric_fields = [f for f, t in fields.items() if t == "numeric"]
+        alias_mapping = {}  # Maps sanitized alias -> original field name
 
         # Build SELECT clause based on number of group fields
         if len(group_fields) == 1:
@@ -446,12 +494,20 @@ class SummaryQueryBuilder:
 
             for field in numeric_fields:
                 field_safe = field.replace("'", "''")
+                field_alias = self.sanitize_field_for_alias(field)
+
+                # Track the mapping for each aggregation type
+                alias_mapping[f"{field_alias}_count"] = field
+                alias_mapping[f"{field_alias}_min"] = field
+                alias_mapping[f"{field_alias}_max"] = field
+                alias_mapping[f"{field_alias}_sum"] = field
+
                 select_parts.extend(
                     [
-                        f"COUNT(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_count",
-                        f"MIN(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_min",
-                        f"MAX(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_max",
-                        f"SUM(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_sum",
+                        f"COUNT(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_count",
+                        f"MIN(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_min",
+                        f"MAX(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_max",
+                        f"SUM(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_sum",
                     ]
                 )
 
@@ -496,12 +552,20 @@ class SummaryQueryBuilder:
 
             for field in numeric_fields:
                 field_safe = field.replace("'", "''")
+                field_alias = self.sanitize_field_for_alias(field)
+
+                # Track the mapping for each aggregation type
+                alias_mapping[f"{field_alias}_count"] = field
+                alias_mapping[f"{field_alias}_min"] = field
+                alias_mapping[f"{field_alias}_max"] = field
+                alias_mapping[f"{field_alias}_sum"] = field
+
                 select_parts.extend(
                     [
-                        f"COUNT(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_count",
-                        f"MIN(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_min",
-                        f"MAX(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_max",
-                        f"SUM(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field}_sum",
+                        f"COUNT(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_count",
+                        f"MIN(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_min",
+                        f"MAX(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_max",
+                        f"SUM(CASE WHEN m.key = '{field_safe}' THEN m.numeric_value END) as {field_alias}_sum",
                     ]
                 )
 
@@ -553,7 +617,7 @@ class SummaryQueryBuilder:
 
             params = params_list + filter_params + [scenario_id]
 
-        return sql, params
+        return sql, params, alias_mapping
 
     def execute_query(self, sql: str, params: List) -> List[Dict[str, Any]]:
         """

--- a/proenergia/datasets/tests/test_scenario_data_views.py
+++ b/proenergia/datasets/tests/test_scenario_data_views.py
@@ -564,6 +564,98 @@ class TestMultiFieldSummaryView(APITestCase):
         self.assertEqual(res.status_code, 400)
         self.assertIn("Maximum of 2 group_by fields allowed", res.json()["error"])
 
+    def test_field_names_with_special_characters(self):
+        """Test that field names with spaces and special characters work correctly"""
+        # Add fields with special characters to the model configuration
+        self.model.metric_field_types["Staple_Crop Production (t/y)"] = "numeric"
+        self.model.metric_field_types["Cash Crop Production (t/y)"] = "numeric"
+        self.model.metric_field_types["Perishable_Crop Production (t/y)"] = "numeric"
+        self.model.save()
+
+        # Create test data with special character field names
+        for feature_id in [1, 2, 3]:
+            ScenarioDataMetrics.objects.create(
+                scenario=self.scenario,
+                feature_id=feature_id,
+                key="Staple_Crop Production (t/y)",
+                numeric_value=100.0 * feature_id,
+            )
+            ScenarioDataMetrics.objects.create(
+                scenario=self.scenario,
+                feature_id=feature_id,
+                key="Cash Crop Production (t/y)",
+                numeric_value=50.0 * feature_id,
+            )
+            ScenarioDataMetrics.objects.create(
+                scenario=self.scenario,
+                feature_id=feature_id,
+                key="Perishable_Crop Production (t/y)",
+                numeric_value=75.0 * feature_id,
+            )
+
+        # Test single field with special characters
+        url = reverse("datasets:scenario-summaries", args=[self.scenario.id])
+        res = self.client.get(url, {"fields": "Staple_Crop Production (t/y)"})
+
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertIn("Staple_Crop Production (t/y)", data["summaries"])
+
+        staple_summary = data["summaries"]["Staple_Crop Production (t/y)"]
+        self.assertEqual(staple_summary["type"], "numeric")
+        self.assertEqual(staple_summary["count"], 3)
+        self.assertEqual(staple_summary["min"], 100.0)
+        self.assertEqual(staple_summary["max"], 300.0)
+        self.assertEqual(staple_summary["sum"], 600.0)
+
+        # Test multiple fields with special characters
+        res = self.client.get(
+            url,
+            {
+                "fields": "Staple_Crop Production (t/y),Cash Crop Production (t/y),Perishable_Crop Production (t/y)"
+            },
+        )
+
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertIn("Staple_Crop Production (t/y)", data["summaries"])
+        self.assertIn("Cash Crop Production (t/y)", data["summaries"])
+        self.assertIn("Perishable_Crop Production (t/y)", data["summaries"])
+
+        cash_summary = data["summaries"]["Cash Crop Production (t/y)"]
+        self.assertEqual(cash_summary["count"], 3)
+        self.assertEqual(cash_summary["sum"], 300.0)
+
+        perishable_summary = data["summaries"]["Perishable_Crop Production (t/y)"]
+        self.assertEqual(perishable_summary["count"], 3)
+        self.assertEqual(perishable_summary["sum"], 450.0)
+
+        # Test with filters
+        res = self.client.get(
+            url,
+            {
+                "fields": "Staple_Crop Production (t/y)",
+                "q": "Cash Crop Production (t/y)__min=100",
+            },
+        )
+
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        filtered_summary = data["summaries"]["Staple_Crop Production (t/y)"]
+        # Should only include features 2 and 3 (where Cash Crop >= 100)
+        self.assertEqual(filtered_summary["count"], 2)
+        self.assertEqual(filtered_summary["min"], 200.0)
+
+        # Test with group_by
+        res = self.client.get(
+            url,
+            {"fields": "Staple_Crop Production (t/y)", "group_by": "Technology2030"},
+        )
+
+        self.assertEqual(res.status_code, 200)
+        data = res.json()
+        self.assertIn("grouped", data["summaries"]["Staple_Crop Production (t/y)"])
+
     def test_group_by_two_fields_with_filters(self):
         """Test nested grouping with filters applied"""
         url = reverse("datasets:scenario-summaries", args=[self.scenario.id])


### PR DESCRIPTION
Currently, a request like this gives a 500: https://proenergia-staging.ds.io/api/v1/scenario/6/summaries/?fields=Staple_Crop+Production+(t%2Fy),Perishable_Crop+Production+(t%2Fy),Cash+Crop+Production+(t%2Fy)

This is because of special characters in the field names that are not handled correctly when we construct the postgres SQL queries. This PR adds a sanitization function to create sanitized versions of the field names that work in the Postgres queries and aliases, and then maps results back to the original names for the response.

The frontend should see no change in behaviour, it should just fix the 500 - this also adds a test that failed before this fix and passes after.