### PR TITLE
increase celery worker timeouts

### DIFF
--- a/deploy/configs/systemd/proenergia-celery.service
+++ b/deploy/configs/systemd/proenergia-celery.service
@@ -18,8 +18,8 @@ ExecStart=/bin/bash -c '/var/www/proenergia/app/venv/bin/celery -A proenergia wo
     --loglevel=${CELERY_LOG_LEVEL:-info} \
     --concurrency=${CELERY_WORKER_CONCURRENCY:-4} \
     --max-tasks-per-child=${CELERY_WORKER_MAX_TASKS_PER_CHILD:-1000} \
-    --time-limit=${CELERY_TASK_TIME_LIMIT:-1800} \
-    --soft-time-limit=${CELERY_TASK_SOFT_TIME_LIMIT:-1740}'
+    --time-limit=${CELERY_TASK_TIME_LIMIT:-21600} \
+    --soft-time-limit=${CELERY_TASK_SOFT_TIME_LIMIT:-21540}'
 
 # Graceful shutdown
 KillMode=mixed


### PR DESCRIPTION
Increases the celery worker timeouts from 30 mins to 6 hours to avoid timeout errors, fixes #85 

For the record, this is what the error in the celery logs looked like: 

```
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]: [2026-02-26 20:14:35,095: ERROR/MainProcess] Task handler raised error: TimeLimitExceeded(1800.0)
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]: Traceback (most recent call last):
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]:   File "/var/www/proenergia/app/venv/lib/python3.12/site-packages/billiard/pool.py", line 684, in on_hard_timeout
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]:     raise TimeLimitExceeded(job._timeout)
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]: billiard.einfo.ExceptionWithTraceback:
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]: """
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]: Traceback (most recent call last):
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]:   File "/var/www/proenergia/app/venv/lib/python3.12/site-packages/billiard/pool.py", line 684, in on_hard_timeout
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]:     raise TimeLimitExceeded(job._timeout)
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]: billiard.exceptions.TimeLimitExceeded: TimeLimitExceeded(1800.0,)
Feb 26 20:14:37 ip-172-31-21-225 bash[3307151]: """
```