### PR TITLE
increase memory limits for celery systemd service

### DIFF
--- a/deploy/configs/systemd/proenergia-celery.service
+++ b/deploy/configs/systemd/proenergia-celery.service
@@ -42,8 +42,8 @@ ReadWritePaths=/var/www/proenergia /var/log/proenergia /var/run/proenergia-celer
 
 # Resource limits
 LimitNOFILE=65536
-MemoryHigh=3G
-MemoryMax=4G
+MemoryHigh=16G
+MemoryMax=20G
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Increase the overall memory limit for the celery workers (change is already manually applied on the server, this adds it to the deploy scripts).

cc @willemarcel 