### PR TITLE
Improve error handling on ScenarioFile processing

### DIFF
--- a/proenergia/datasets/admin.py
+++ b/proenergia/datasets/admin.py
@@ -10,7 +10,6 @@ from unfold.admin import ModelAdmin
 from proenergia.datasets.tasks import (
     generate_pmtiles,
     generate_scenario_pmtiles,
-    import_scenario_data_csv,
 )
 
 from .models import (
@@ -399,7 +398,6 @@ class ScenarioFileAdmin(ModelAdmin):
 
         for obj in files:
             generate_scenario_pmtiles.delay(obj.id)
-            import_scenario_data_csv.delay(obj.id)
 
         if files.count():
             messages.success(

--- a/proenergia/datasets/models.py
+++ b/proenergia/datasets/models.py
@@ -14,7 +14,6 @@ from django.utils.translation import gettext_lazy as _
 from proenergia.datasets.tasks import (
     generate_pmtiles,
     generate_scenario_pmtiles,
-    import_scenario_data_csv,
 )
 from proenergia.datasets.utils import get_file_variant
 
@@ -311,7 +310,6 @@ def trigger_generate_scenario_pmtiles(sender, instance, created, **kwargs):
     """Trigger generate_scenario_pmtiles Celery task when a new ScenarioFile instance is created."""
     if created:
         generate_scenario_pmtiles.delay(instance.id)
-        import_scenario_data_csv.delay(instance.id)
 
 
 class ScenarioData(models.Model):

--- a/proenergia/datasets/tasks.py
+++ b/proenergia/datasets/tasks.py
@@ -125,7 +125,7 @@ def merge_vector_scenario_files(
         )
     except Exception as e:
         logger.error(f"Failed to read CSV file {scenario_file_path}: {e}")
-        raise
+        raise e
 
     vector.merge(model_data, on="id").to_file(merged_file_path, driver="FlatGeobuf")
     logger.info(f"Merged file created on {merged_file_path}.")
@@ -172,10 +172,9 @@ def generate_scenario_pmtiles(self, id: int):
         )
         call_tippecanoe(fgb_path, get_file_variant(sf.file.path, "pmtiles"))
 
-        sf.status = "ready"
-        sf.save(update_fields=["status"])
+        import_scenario_data_csv(id)
     except Exception as e:
-        print(f"Unexpected error: {e}")
+        print(f"Unexpected error during PMTiles generation: {e}")
         sf.error_message = e
         sf.status = "error"
         sf.save(update_fields=["status", "error_message"])
@@ -326,17 +325,9 @@ def sync_scenario_metrics(scenario):
     )
 
 
-@shared_task(bind=True, max_retries=5, default_retry_delay=2)
-def import_scenario_data_csv(self, scenario_file_id: int):
+def import_scenario_data_csv(scenario_file_id: int):
     ScenarioFile = apps.get_model("datasets", "ScenarioFile")
-    try:
-        importer = DataImporter(scenario_file_id)
-    except ScenarioFile.DoesNotExist as e:
-        # Retry with exponential backoff
-        logger.warning(
-            f"ScenarioFile {id} not found, retrying... (attempt {self.request.retries + 1})"
-        )
-        raise self.retry(exc=e, countdown=2**self.request.retries)
+    importer = DataImporter(scenario_file_id)
 
     stats = importer.import_csv()
     logger.info(
@@ -344,9 +335,16 @@ def import_scenario_data_csv(self, scenario_file_id: int):
     )
 
     # Sync metrics after successful import
+    sf = ScenarioFile.objects.get(id=scenario_file_id)
     try:
-        scenario = ScenarioFile.objects.get(id=scenario_file_id).scenario
+        scenario = sf.scenario
         sync_scenario_metrics(scenario)
+
+        sf.status = "ready"
+        sf.save(update_fields=["status"])
         logger.info(f"Metrics synced successfully for scenario {scenario.id}")
     except Exception as e:
         logger.error(f"Failed to sync metrics for scenario: {e}")
+        sf.status = "error"
+        sf.error_message = e
+        sf.save(update_fields=["status", "error_message"])

--- a/proenergia/datasets/tests/test_scenario_data_views.py
+++ b/proenergia/datasets/tests/test_scenario_data_views.py
@@ -19,10 +19,9 @@ from ..models import (
 
 
 class TestScenarioDataDetailViews(APITestCase):
-    @patch("proenergia.datasets.tasks.import_scenario_data_csv.delay")
     @patch("proenergia.datasets.tasks.generate_pmtiles.delay")
     @patch("proenergia.datasets.tasks.generate_scenario_pmtiles.delay")
-    def setUp(self, mock_1, mock_2, mock_3):
+    def setUp(self, mock_1, mock_2):
         self.scenario_csv = "./proenergia/datasets/fixtures/scenario.csv"
         self.superadmin = get_user_model().objects.create_superuser(
             username="superadmin", email="admin@example.com", password="testpass123"

--- a/proenergia/datasets/tests/test_tasks.py
+++ b/proenergia/datasets/tests/test_tasks.py
@@ -101,10 +101,11 @@ class TestScenarioFilePostSaveTasks(TestCase):
         self.assertTrue("location" in merged_gdf.columns)
         self.assertFalse("country" in merged_gdf.columns)
 
-    @patch("proenergia.datasets.tasks.import_scenario_data_csv.delay")
     @patch("proenergia.datasets.tasks.generate_pmtiles.delay")
     @patch("proenergia.datasets.tasks.generate_scenario_pmtiles.delay")
-    def test_generate_scenario_pmtiles(self, mock_scenario, mock_2, mock_importer):
+    def test_generate_scenario_pmtiles(
+        self, mock_generate_scenario_pmtiles, mock_generate_pmtiles
+    ):
         self.superadmin = get_user_model().objects.create_superuser(
             username="superadmin", email="admin@example.com", password="testpass123"
         )
@@ -160,8 +161,8 @@ class TestScenarioFilePostSaveTasks(TestCase):
             created_by=self.superadmin,
             status="ready",
         )
-        mock_scenario.assert_called_with(self.scenario_file_1.id)
-        mock_importer.assert_called_with(self.scenario_file_1.id)
+        mock_generate_pmtiles.assert_called_with(self.vector_file_1.id)
+        mock_generate_scenario_pmtiles.assert_called_with(self.scenario_file_1.id)
 
         # import csv and check ScenarioData items were created
         import_scenario_data_csv(self.scenario_file_1.id)
@@ -189,8 +190,8 @@ class TestScenarioFilePostSaveTasks(TestCase):
             status="ready",
         )
 
-        mock_scenario.assert_called_with(self.scenario_file_2.id)
-        mock_importer.assert_called_with(self.scenario_file_2.id)
+        mock_generate_pmtiles.assert_called_with(self.vector_file_1.id)
+        mock_generate_scenario_pmtiles.assert_called_with(self.scenario_file_2.id)
 
         import_scenario_data_csv(self.scenario_file_2.id)
         self.assertEqual(


### PR DESCRIPTION
Related to https://github.com/developmentseed/moz-proenergia-backend/issues/94

Some changes:
- Only import data to the table if the scenario's pmtiles generation is successfully completed
- It will save error messages during data import to the ScenarioFile
- If a required column is missing in the CSV, the information will be saved to the error_message file