### PR TITLE
tweak worker config, timeouts and memory usage, addressing #90

### DIFF
--- a/deploy/configs/gunicorn/gunicorn.conf.py
+++ b/deploy/configs/gunicorn/gunicorn.conf.py
@@ -6,10 +6,12 @@ bind = "127.0.0.1:8000"
 backlog = 2048
 
 # Worker processes
-workers = multiprocessing.cpu_count() * 2 + 1
+# Reduced workers to prevent memory exhaustion
+# Original: multiprocessing.cpu_count() * 2 + 1
+workers = min(3, multiprocessing.cpu_count())  # Max 3 workers
 worker_class = "sync"
 worker_connections = 1000
-timeout = 30
+timeout = 120  # Increased from 30 to handle long queries
 keepalive = 2
 
 # Restart workers after this many requests, to prevent memory leaks

--- a/deploy/configs/nginx/proenergia.conf
+++ b/deploy/configs/nginx/proenergia.conf
@@ -54,10 +54,10 @@ server {
         proxy_cache_bypass $http_upgrade;
         proxy_redirect off;
         
-        # Timeout settings
-        proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        # Timeout settings (matched to Gunicorn timeout)
+        proxy_connect_timeout 120s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
     }
 
     # Health check endpoint

--- a/deploy/configs/systemd/proenergia.service
+++ b/deploy/configs/systemd/proenergia.service
@@ -30,8 +30,12 @@ ReadWritePaths=/var/www/proenergia /var/log/proenergia /var/run/proenergia
 
 # Resource limits
 LimitNOFILE=65536
-MemoryHigh=8G
+# Reduced MemoryHigh to trigger memory pressure earlier and prevent OOM
+MemoryHigh=4G
 MemoryMax=10G
+MemorySwapMax=4G
+# Continue running even if some processes get OOM killed
+OOMPolicy=continue
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Config changes to reduce the number of gunicorn workers, restrict memory usage per worker (plus allow swap) and increase timeouts - was using https://proenergia-staging.ds.io/api/v1/scenario/1/summaries/?fields=New_MV_Lines_(km),New_LV_Lines_(km),New_Distribution_Transformers_(75_kVA),Average_LCOE_(USD%2FkWh),AverageConnectionCost_(USD),NewHHConnectionsTotal,Posto,Pop2030,NewCapacityTotal,InvestmentCostTotal,InvestmentDist,InvestmentGen,LCOETotal,InvCostConnection&group_by=TechnologySelection as the test slow query that was previously resulting in OOM errors and gunicorn restarts.

I've applied these changes already on the server, so I'll merge this in - combined with our caching setup, this should be okay and not result in any perceptible issues for users apart from an occasional slightly slow page load when not fetching from cache. (If this is a problem, we can look into auto-populating the cache for these kinds of "default" queries with no filters applied).

If we did have time to dig deeper and improve the summary querying, there's two things we could do:

 - Try and reduce the number of `ids` being held in memory in python - the way we query right now, we do fetch all ids to do the group_by querying, and this seems suboptimal and something that can be improved.
 - Go with a fully different approach for the aggregation queries using `DuckDB` instead of postgres for aggregates. I think this would be fun to experiment with at some point.

Currently, I think just tweaking these configs should be fine and get the endpoint functional.

cc @willemarcel @LanesGood 