### PR TITLE
add scripts to setup and update frontend + nginx config

### DIFF
--- a/deploy/configs/nginx/proenergia-frontend.conf
+++ b/deploy/configs/nginx/proenergia-frontend.conf
@@ -1,0 +1,36 @@
+server {
+    listen 80;
+    server_name your-frontend-domain.com;
+
+    root /var/www/proenergia/frontend/out;
+    index index.html;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'" always;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json image/svg+xml;
+
+    # Cache static assets (NextJS build output)
+    location /_next/static/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # NextJS static export routing
+    location / {
+        try_files $uri $uri.html $uri/ /index.html;
+    }
+
+    # Deny access to dotfiles
+    location ~ /\. {
+        deny all;
+    }
+}

--- a/deploy/scripts/06_setup_frontend.sh
+++ b/deploy/scripts/06_setup_frontend.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -e
+
+echo "=== Setting up ProEnergia frontend ==="
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root (use sudo)"
+   exit 1
+fi
+
+# Check for required domain parameter
+if [ $# -eq 0 ] || [ -z "$1" ]; then
+    echo "Error: Domain parameter is required"
+    echo "Usage: $0 <frontend_domain> [email]"
+    echo "Example: $0 frontend.example.com admin@example.com"
+    exit 1
+fi
+
+DOMAIN="$1"
+EMAIL=${2:-"admin@$DOMAIN"}
+FRONTEND_DIR="/var/www/proenergia/frontend"
+REPO_URL="https://github.com/developmentseed/moz-proenergia-web.git"
+
+echo "Setting up frontend for domain: $DOMAIN"
+echo "SSL certificate email: $EMAIL"
+
+echo ""
+echo "=== Step 1: Installing Node.js v24 ==="
+
+curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+apt-get install -y nodejs
+
+echo "Node.js version: $(node --version)"
+
+echo ""
+echo "=== Step 2: Installing pnpm ==="
+
+npm install -g pnpm
+echo "pnpm version: $(pnpm --version)"
+
+echo ""
+echo "=== Step 3: Cloning frontend repository ==="
+
+if [ -d "$FRONTEND_DIR" ]; then
+    echo "Frontend directory already exists, pulling latest..."
+    sudo -u proenergia bash -c "cd $FRONTEND_DIR && git fetch origin && git reset --hard origin/main"
+else
+    git clone "$REPO_URL" "$FRONTEND_DIR"
+fi
+
+chown -R proenergia:proenergia "$FRONTEND_DIR"
+
+echo ""
+echo "=== Step 4: Building frontend ==="
+
+sudo -u proenergia bash -c "cd $FRONTEND_DIR && pnpm install && pnpm run build"
+
+echo ""
+echo "=== Step 5: Configuring nginx ==="
+
+# Copy nginx configuration
+cp /var/www/proenergia/app/deploy/configs/nginx/proenergia-frontend.conf /etc/nginx/sites-available/
+sed -i "s/your-frontend-domain.com/$DOMAIN/g" /etc/nginx/sites-available/proenergia-frontend.conf
+
+# Enable nginx site
+ln -sf /etc/nginx/sites-available/proenergia-frontend.conf /etc/nginx/sites-enabled/
+
+# Test nginx configuration
+nginx -t
+
+# Reload nginx
+systemctl reload nginx
+
+echo ""
+echo "=== Step 6: Setting up SSL certificate ==="
+
+certbot --nginx -d $DOMAIN --email $EMAIL --agree-tos --non-interactive --redirect || {
+    echo ""
+    echo "WARNING: SSL certificate setup failed. The frontend will run on HTTP only."
+    echo "To retry SSL setup later, run:"
+    echo "  sudo certbot --nginx -d $DOMAIN --email $EMAIL --agree-tos --non-interactive --redirect"
+    echo ""
+}
+
+# Setup auto-renewal (only if certbot is installed)
+if command -v certbot &> /dev/null; then
+    systemctl enable certbot.timer 2>/dev/null || true
+    systemctl start certbot.timer 2>/dev/null || true
+fi
+
+echo ""
+echo "========================================================================="
+echo "                     FRONTEND SETUP COMPLETE                            "
+echo "========================================================================="
+echo ""
+echo "Your frontend should now be available at: https://$DOMAIN"
+echo ""
+echo "To update the frontend later, run as proenergia user:"
+echo "  sudo -u proenergia /var/www/proenergia/app/deploy/scripts/07_update_frontend.sh"

--- a/deploy/scripts/07_update_frontend.sh
+++ b/deploy/scripts/07_update_frontend.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+echo "=== Updating ProEnergia frontend ==="
+
+FRONTEND_DIR="/var/www/proenergia/frontend"
+
+# Check if running as proenergia user
+if [[ $(whoami) != "proenergia" ]]; then
+   echo "This script should be run as the proenergia user"
+   echo "Run: sudo -u proenergia $0"
+   exit 1
+fi
+
+cd $FRONTEND_DIR
+
+echo "Pulling latest code..."
+git fetch origin
+git reset --hard origin/main
+
+echo "Installing dependencies..."
+pnpm install
+
+echo "Building frontend..."
+pnpm run build
+
+echo "=== Frontend update complete ==="


### PR DESCRIPTION
Refs #106 

To deploy frontend:

 - Create a DNS A record to point frontend domain to the server (eg. point proenergia-frontend-staging.ds.io to `54.162.136.67`)
 - Run `deploy/scripts/06_setup_frontend.sh <domain>` to setup frontend: copy nginx config for domain to serve static files from build folder, setup SSL, check-out code and run `pnpm run build`

Once we get this working and deployed, we can look into performing the re-build via an admin action, etc. 